### PR TITLE
resize blocks on narrow screens

### DIFF
--- a/src/css/base.css
+++ b/src/css/base.css
@@ -11,8 +11,10 @@ kbd {
   background: rgba(175, 184, 193, 0.2);
   margin: 0;
   font-size: 85%;
-  white-space: break-spaces;
+  white-space: pre;
   width: max-content;
+  max-width: calc(100% - 8px);
+  overflow-x: auto;
 }
 
 code {

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -10,9 +10,17 @@ kbd {
   padding: 0.2em 0.4em;
   background: rgba(175, 184, 193, 0.2);
   margin: 0;
-  font-size: 85%;
-  white-space: pre;
   width: max-content;
+}
+
+code,
+kbd {
+  white-space: break-spaces;
+  font-size: 85%;
+}
+
+pre {
+  white-space: pre;
   max-width: calc(100% - 8px);
   overflow-x: auto;
 }


### PR DESCRIPTION
There are a few snags I want to call attention to. I don't think they are issues, but I just want input on them.

Because of how overflow works, when the scroll appears the padding is essentially gone. That means text will be flush to right edge when scroll is present.

Second thing is that I had to do `max-width: calc(100% - 8px);` to fix fit issues due to scroll bar. Basically still overflows if I use 100%. That looks a little jank and I found it's not compatible with older browsers ([see link to SO](https://stackoverflow.com/a/14367262))