### PR TITLE
Feature/improve code blocks

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,5 @@
 const eleventyNavigationPlugin = require("@11ty/eleventy-navigation");
+const syntaxHighlightPlugin = require("@11ty/eleventy-plugin-syntaxhighlight");
 
 module.exports = function (eleventyConfig) {
   eleventyConfig.addWatchTarget("./src/**");
@@ -11,6 +12,9 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addPassthroughCopy({
     "./src/general-pages/installation/*.png": "/installation",
   });
+  // do not place syntaxHighlightPlugin after eleventyNavigationPlugin
+  // it prevents styles from loading
+  eleventyConfig.addPlugin(syntaxHighlightPlugin);
   eleventyConfig.addPlugin(eleventyNavigationPlugin);
   return {
     dir: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "desmodder-website",
       "version": "0.1.0",
+      "dependencies": {
+        "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0"
+      },
       "devDependencies": {
         "@11ty/eleventy": "^2.0.1",
         "@11ty/eleventy-navigation": "^0.3.5"
@@ -166,6 +169,18 @@
       "dev": true,
       "dependencies": {
         "dependency-graph": "^0.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/eleventy-plugin-syntaxhighlight": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-syntaxhighlight/-/eleventy-plugin-syntaxhighlight-5.0.0.tgz",
+      "integrity": "sha512-y9BUmP1GofmbJgxM1+ky/UpFCpD8JSOeLeKItUs0WApgnrHk9haHziW7lS86lbArX5SiCVo4zTTw9x53gvRCaA==",
+      "dependencies": {
+        "prismjs": "^1.29.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1858,6 +1873,14 @@
         "node": ">= 4"
       }
     },
+    "node_modules/prismjs": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -2513,6 +2536,14 @@
       "dev": true,
       "requires": {
         "dependency-graph": "^0.11.0"
+      }
+    },
+    "@11ty/eleventy-plugin-syntaxhighlight": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-plugin-syntaxhighlight/-/eleventy-plugin-syntaxhighlight-5.0.0.tgz",
+      "integrity": "sha512-y9BUmP1GofmbJgxM1+ky/UpFCpD8JSOeLeKItUs0WApgnrHk9haHziW7lS86lbArX5SiCVo4zTTw9x53gvRCaA==",
+      "requires": {
+        "prismjs": "^1.29.0"
       }
     },
     "@11ty/eleventy-utils": {
@@ -3750,6 +3781,11 @@
         "parse-srcset": "^1.0.2",
         "promise-each": "^2.2.0"
       }
+    },
+    "prismjs": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="
     },
     "promise": {
       "version": "7.3.1",

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   "devDependencies": {
     "@11ty/eleventy": "^2.0.1",
     "@11ty/eleventy-navigation": "^0.3.5"
+  },
+  "dependencies": {
+    "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.0"
   }
 }

--- a/src/_includes/base.liquid
+++ b/src/_includes/base.liquid
@@ -13,6 +13,10 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
     <link rel="manifest" href="/site.webmanifest">
+    <link
+      href="https://unpkg.com/prismjs@1.20.0/themes/prism-okaidia.css"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <header>

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -52,6 +52,10 @@ pre code {
   white-space: unset;
 }
 
+img {
+  width: 100%;
+}
+
 /* Header layout */
 
 header {

--- a/src/plugin-pages/text-mode/statements.md
+++ b/src/plugin-pages/text-mode/statements.md
@@ -31,7 +31,7 @@ a = 5;
 
 ## Function Definition
 
-```
+```js
 f(x) = x + 1
 f(a,b,c) = a + 2 * b + c
 ```
@@ -40,7 +40,7 @@ No styles are supported besides the default `id`, `pinned`, and `errorHidden`
 
 ## Visualizations
 
-```
+```js
 stats(L)
 histogram(L)
 boxplot(L)
@@ -122,6 +122,6 @@ a = 5 @{
 
 ### Regression styles
 
-```
+```js
 y1 ~ a * b ^ x1 @{ logMode: true }
 ```


### PR DESCRIPTION
Adds a syntax highlighting plugin to eleventy to make the code blocks look nicer. The last commit does not match with the branch name, but I was also going to make that PR and since it's small thought of bundling it here as well.

I added descriptions to each commit.

Finally, there was an issue that themes were not loading if I put the syntax highlight plugin _after_ the navigation plugin. Reversing the order fixed the issue, but I am not entirely sure why. I thought this was important to highlight (pun intended haha).